### PR TITLE
Improved h2o-core dependency management in POM file.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,141 +59,20 @@
             <artifactId>junit</artifactId>
             <version>4.11</version>
         </dependency>
-	<dependency>
-	  <artifactId>h2o-core</artifactId>
-	  <groupId>h2o-local</groupId>
-	  <version>0.3</version>
-	  <scope>system</scope>
-	  <systemPath>/Users/avati/work/h2o/target/h2o.jar</systemPath>
-	</dependency>
-
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
-      <scope>test</scope>
-    </dependency>
-    
-    <!-- =Compile time dependencies= -->
-    <!-- ==Apache dependencies== -->
-    <dependency>
-      <groupId>commons-lang</groupId>
-      <artifactId>commons-lang</artifactId>
-      <version>2.4</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.1.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.15</version>
-      <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>mail</artifactId>
-          <groupId>javax.mail</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jms</artifactId>
-          <groupId>javax.jms</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jmxtools</artifactId>
-          <groupId>com.sun.jdmk</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>jmxri</artifactId>
-          <groupId>com.sun.jmx</groupId>
-        </exclusion>
-      </exclusions>
-    </dependency>            
-    <!-- ==Google dependencies== -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>12.0.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.code.gson</groupId>
-      <artifactId>gson</artifactId>
-      <version>2.2.2</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- ==Jama is given explicitely - it was modified and compiled by @tomas ==
-    <dependency>
-      <groupId>gov.nist.math</groupId>
-      <artifactId>jama</artifactId>
-      <version>1.0.2-modified</version>
-      <scope>compile</scope>
-    </dependency>
- -->
-    <!-- ==POI dependencies== -->
-    <dependency>
-      <groupId>org.apache.poi</groupId>
-      <artifactId>poi-ooxml</artifactId>
-      <version>3.8</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- ==jets3t dependencies== -->
-    <dependency>
-      <groupId>net.java.dev.jets3t</groupId>
-      <artifactId>jets3t</artifactId>
-      <version>0.6.1</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- ==Java AWS SDK dependencies== -->
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
-      <version>1.3.27</version>
-      <scope>compile</scope>
-    </dependency>   
-    <!-- ==Javassist dependency -->
-    <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.16.1-GA</version>
-      <scope>compile</scope>
-    </dependency>
-    <!-- ==Jogamp dependencies for NN== -->
-    <dependency>
-      <groupId>org.jogamp.gluegen</groupId>
-      <artifactId>gluegen-rt-main</artifactId>
-      <version>2.0.2-rc12</version>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jogamp.jocl</groupId>
-      <artifactId>jocl</artifactId>
-      <version>2.0.2-rc12</version>
-    </dependency>
-    <!-- ==Hadoop core dependencies==
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>${h2o.hadoop.version}</version>
-      <scope>compile</scope>
-    </dependency>
--->
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>0.23.4</version>
-      <scope>compile</scope>
-    </dependency>
-
+        <!-- H2O core containing only H2O classes - packages water.*, hex.*, no external dependencies -->
+        <dependency>
+          <artifactId>h2o-core</artifactId>
+          <groupId>ai.h2o</groupId>
+          <version>2.5-SNAPSHOT</version>
+          <scope>compile</scope>
+        </dependency>
+        <dependency>
+          <artifactId>h2o-core</artifactId>
+          <groupId>ai.h2o</groupId>
+          <version>2.5-SNAPSHOT</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/oxdata/math/H2OMatrix.java
+++ b/src/main/java/com/oxdata/math/H2OMatrix.java
@@ -1,12 +1,25 @@
 package com.oxdata.math;
 
-import org.apache.mahout.math.*;
+import org.apache.mahout.math.AbstractMatrix;
+import org.apache.mahout.math.CardinalityException;
+import org.apache.mahout.math.Matrix;
+import org.apache.mahout.math.MatrixSlice;
+import org.apache.mahout.math.Vector;
 import org.apache.mahout.math.function.DoubleDoubleFunction;
 import org.apache.mahout.math.function.DoubleFunction;
 import org.apache.mahout.math.function.VectorFunction;
 
-import water.*;
-import water.fvec.*;
+import water.AutoBuffer;
+import water.Freezable;
+import water.Futures;
+import water.Key;
+import water.MRTask2;
+import water.fvec.AppendableVec;
+import water.fvec.Chunk;
+import water.fvec.Frame;
+import water.fvec.NewChunk;
+import water.fvec.Vec;
+import water.util.FrameUtils;
 
 /**
  * Implement a simple matrix type to emulate what an h2o based matrix would need.
@@ -52,7 +65,7 @@ public class H2OMatrix extends AbstractMatrix implements Freezable {
     }
   }
 
-  public H2OMatrix( java.io.File file ) { this(water.TestUtil.parseFrame(null,file)); }
+  public H2OMatrix( java.io.File file ) { this(FrameUtils.parseFrame(null,file)); }
 
   private H2OMatrix( Frame fr ) {
     super((int) fr.numRows(), fr.numCols());


### PR DESCRIPTION
H2O now uses maven dependency management to publish H2O artifacts into Sonatype repository.
So far we have no maven release, only publishing snapshots.

Hence I changed h2o-matrix project dependencies:
- put proper dependency on h2o-core 2.5-SNAPSHOT
- put additional test dependency on h2o-core (type:test-jar), since H2O core tests
  contain H2O test harness (class water.TestUtil)
- removed dependency on water.TestUtil from project app code

Note: mvn test command still not working since H2O does not yet support
proper test execution via JUnitRunner (problem with classloading)
