### PR TITLE
Added sonatype snapshot repository.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,20 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <!-- Sonatype snapshot repository for fetching H2O snapshots -->
+    <repositories>
+      <repository>
+        <id>oss.sonatype.org-snapshot</id>
+        <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+        <releases>
+          <enabled>false</enabled>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+      </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.mahout</groupId>


### PR DESCRIPTION
Now Maven should fetch h2o-core snapshot from Sonatype snapshot repository.
